### PR TITLE
Rename to Discord Archiver and overhaul README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,79 +1,71 @@
-# 🗄️ Discord Personal History Backup
+# 🗄️ Discord Archiver
 
-> **A local utility for archiving your own message history and server data for offline viewing and data sovereignty.**
+> **A self-hosted, privacy-first tool for archiving your Discord server message history to your own machine — no cloud, no third parties, just your data.**
 
-![Python](https://img.shields.io/badge/Python-3.8+-blue?logo=python)
-![Flask](https://img.shields.io/badge/Flask-3.0-green?logo=flask)
-![Discord.py](https://img.shields.io/badge/discord.py-2.3-blueviolet?logo=discord)
+![Python](https://img.shields.io/badge/Python-3.10+-blue?logo=python)
+![Flask](https://img.shields.io/badge/Flask-3.0+-green?logo=flask)
+![Discord.py](https://img.shields.io/badge/discord.py-2.3+-blueviolet?logo=discord)
 ![License](https://img.shields.io/badge/License-MIT-yellow)
+![Platform](https://img.shields.io/badge/Platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey)
 
 ---
 
 > **⚠️ Compliance & Safety Warning**
 >
-> This tool is designed for **personal archival purposes only** (e.g., backing up your own servers or DMs).
+> This tool is designed for **personal archival purposes only** — backing up your own servers or message history.
 >
-> * **Do not** use this tool to mass-scrape servers where you do not have administrative rights.
-> * **Respect Rate Limits:** Aggressive scraping violates Discord's Terms of Service and can result in account termination.
-> * **Privacy:** Do not distribute archives containing other users' data without their consent.
-> * **Liability:** The user assumes all responsibility for data privacy compliance (GDPR/CCPA) and account safety.
+> - **Do not** use this tool to mass-scrape servers you don't own or administer.
+> - **Respect rate limits:** Aggressive scraping violates Discord's Terms of Service and can result in account termination.
+> - **Privacy:** Do not distribute archives containing other users' data without their consent.
+> - **Liability:** The user assumes all responsibility for data privacy compliance (GDPR/CCPA) and account safety.
 
 ---
 
 ## ✨ Features
 
-- 🕸️ **Local Web Interface** — Runs entirely on your machine via a simple browser UI
-- 📄 **Standard JSON and Human-Readable TXT Exports** — Portable formats for long-term archival
-- 🔒 **Self-Hosted: Your Data Stays on Your Machine** — No third-party servers or cloud uploads
-- ⚙️ **Configurable Speed Settings for API Safety** — Adjust concurrency to respect Discord's rate limits
-- 🚀 **Easy Setup** — Minimal dependencies, runs with standard Python
+| Feature | Description |
+|---------|-------------|
+| 🌐 **Local Web UI** | Clean browser-based interface — no command line needed after setup |
+| 📄 **Multiple Export Formats** | JSON, human-readable TXT, per-channel and per-user files |
+| 📎 **Attachment Downloads** | Optionally download images, videos, and files alongside messages |
+| 🔒 **100% Self-Hosted** | Your data never leaves your machine — no cloud, no accounts |
+| ⚙️ **Configurable via `.env`** | Adjust port, concurrency, and more without touching the code |
+| 🔍 **Filter by User, Channel & Date** | Archive only what you need |
+| ⏹️ **Cancellable Downloads** | Stop a running archive at any time |
+| 🛡️ **Safe by Default** | Conservative concurrency defaults to avoid Discord rate limits |
 
 ---
 
-## 📦 What's in the Backup?
+## 📦 What's in the Archive?
 
-Your backup archive includes:
+Every export produces a ZIP file containing:
 
 | File | Description |
 |------|-------------|
-| `*_messages.json` | Complete message data in JSON format (for developers/long-term storage) |
-| `*_readable.txt` | Human-readable text format for easy browsing |
-| `by_channel/*.txt` | Messages organized by channel |
-| `archive_info.json` | Summary metadata with export statistics |
+| `*_messages.json` | Full message data in JSON — portable and developer-friendly |
+| `*_readable.txt` | Human-readable chat log, organized by channel |
+| `by_channel/*.txt` | Individual text file per channel |
+| `by_user/*.json` | Per-user message files *(optional, enable in settings)* |
+| `attachments/` | Downloaded images, videos, and files *(optional)* |
+| `archive_info.json` | Summary: total messages, users, channels, date range |
 
 ---
 
 ## 🚀 Quick Start
 
-### 1. Clone & Install
+### Windows (Easiest)
+
+1. Download or clone this repo
+2. Double-click **`install.bat`** — it checks Python, installs dependencies, and creates a `run.bat` shortcut
+3. Double-click **`run.bat`** to start the app
+4. Open **http://localhost:5000** in your browser
+
+### Manual (Windows / macOS / Linux)
 
 ```bash
-git clone https://github.com/TanaTTV/discord-personal-backup.git
-cd discord-personal-backup
+git clone https://github.com/TanaTTV/discord-archiver.git
+cd discord-archiver
 pip install -r requirements.txt
-```
-
-### 2. Create a Discord Bot
-
-1. Go to [Discord Developer Portal](https://discord.com/developers/applications)
-2. Click **"New Application"** → Name it → Create
-3. Go to **"Bot"** section → Click **"Reset Token"** → Copy it securely
-4. **Enable Required Intents** (scroll down on Bot page):
-   - ✅ MESSAGE CONTENT INTENT
-   - ✅ SERVER MEMBERS INTENT
-
-### 3. Invite Bot to Your Server
-
-1. In Developer Portal → **OAuth2** → **URL Generator**
-2. Check scopes: `bot`
-3. Check permissions: 
-   - ☑️ Read Message History
-   - ☑️ Read Messages/View Channels
-4. Copy & open the generated URL to invite the bot
-
-### 4. Run the Application
-
-```bash
 python app.py
 ```
 
@@ -81,136 +73,159 @@ Open **http://localhost:5000** in your browser.
 
 ---
 
-## ⚙️ Configuration & Safety
+## 🤖 Setting Up a Discord Bot
 
-This tool includes configurable concurrency settings in `app.py`. **We strongly recommend adjusting these for safe, compliant operation.**
+Discord Archiver uses a bot token to read your server's message history through Discord's official API.
 
-Open `app.py` and locate these variables near the top of the file:
+### Step 1 — Create an Application
 
-```python
-CONCURRENT_CHANNELS = 8   # Number of channels to scan simultaneously
-CONCURRENT_DOWNLOADS = 15 # Number of attachments to download at once
-```
+1. Go to the [Discord Developer Portal](https://discord.com/developers/applications)
+2. Click **"New Application"** → give it a name → **Create**
 
-### Recommended Safe Settings
+### Step 2 — Create a Bot
 
-| Variable | Default | Recommended | Description |
-|----------|---------|-------------|-------------|
-| `CONCURRENT_CHANNELS` | `8` | `1` | Set to `1` to fetch channels sequentially and avoid API abuse flags |
-| `CONCURRENT_DOWNLOADS` | `15` | `5` | Set to `5` or lower to prevent rate limiting or IP-based restrictions |
+1. In your application, go to the **Bot** section
+2. Click **"Reset Token"** → copy the token and keep it safe
+3. Scroll down and enable these **Privileged Gateway Intents**:
+   - ✅ **Server Members Intent**
+   - ✅ **Message Content Intent**
 
-> **⚠️ Important:** High concurrency settings may flag your account for API abuse. Discord actively monitors for aggressive API usage patterns. **We recommend keeping these values low** to ensure your bot token and account remain in good standing.
+### Step 3 — Invite the Bot to Your Server
 
----
+1. Go to **OAuth2 → URL Generator**
+2. Under **Scopes**, check: `bot`
+3. Under **Bot Permissions**, check:
+   - ✅ Read Messages / View Channels
+   - ✅ Read Message History
+4. Copy the generated URL, paste it in your browser, and invite the bot to your server
 
-## 📖 How It Works
+### Step 4 — Run & Archive
 
-1. **Authentication** — You provide your Bot Token to authenticate via Discord's official API
-2. **Server Access** — The bot connects to the specified server where it has been invited
-3. **Sequential Fetching** — Message history is fetched sequentially via the official Discord API
-4. **Filtering** — Messages are filtered by the User ID(s) you specify (for personal backup)
-5. **Local Storage** — Data streams securely to local storage in JSON and TXT formats
-6. **Export** — Download a ZIP archive or save directly to your `downloads/` folder
-
----
-
-## 🔍 How to Get IDs
-
-> **First:** Enable Developer Mode in Discord: **Settings → Advanced → Developer Mode**
-
-| ID Type | How to Obtain |
-|---------|---------------|
-| **Bot Token** | Developer Portal → Your Application → Bot → Reset Token → Copy |
-| **Server ID** | Right-click the server icon → "Copy Server ID" |
-| **User ID** | Right-click your username → "Copy User ID" |
-
-### About User ID Filtering
-
-The **User ID** field filters the backup to only include messages from the specified user(s). This is intended for **backing up your own messages** rather than archiving an entire server.
-
-- Leave blank to include all messages (requires appropriate permissions and use case)
-- Enter your own User ID to back up only your personal message history
-- Separate multiple IDs with commas: `123456789,987654321`
+1. Start the app (`run.bat` or `python app.py`)
+2. Paste your **Bot Token** and **Server ID** into the web UI
+3. Click **"Load Channels"** to select which channels to include
+4. Configure your options (date range, user filter, attachments, etc.)
+5. Click **"Start Archive"** and watch the real-time progress
+6. Download your ZIP when it's done
 
 ---
 
-## 📁 Example Output
+## ⚙️ Configuration
 
-**Readable TXT format:**
-```
-================================================================================
-  📝 My Server - Message Archive
-  📊 Total Messages: 1,234
-  📅 Exported: January 03, 2026 at 12:30 AM
-================================================================================
+All settings live in the `.env` file (created automatically from `.env.example` on first run via `install.bat`).
 
---------------------------------------------------------------------------------
-  #general
---------------------------------------------------------------------------------
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PORT` | `5000` | Port the web UI runs on |
+| `CONCURRENT_CHANNELS` | `1` | Channels scanned in parallel — keep at `1` to avoid rate limits |
+| `CONCURRENT_DOWNLOADS` | `5` | Attachment downloads in parallel — keep low to stay safe |
 
-[Jan 15, 2024 at 02:30 PM] YourName:
-    Hello everyone! This is my message.
-    [Attachment: photo.png]
-```
+> **⚠️ Warning:** Raising `CONCURRENT_CHANNELS` or `CONCURRENT_DOWNLOADS` significantly increases the risk of Discord rate-limiting or flagging your bot token.
 
 ---
 
-## ❓ FAQ
+## 🔍 How to Find Your IDs
 
-**What permissions does the bot need?**
-> Minimal permissions: "Read Message History" and "View Channels" only. No admin access required.
+> **First:** Enable Developer Mode — Discord **Settings → Advanced → Developer Mode**
 
-**Can it access private channels?**
-> Only channels where the bot's role has explicit access permissions.
+| ID | How to Get It |
+|----|---------------|
+| **Bot Token** | Developer Portal → Your App → Bot → Reset Token |
+| **Server ID** | Right-click server icon → **Copy Server ID** |
+| **User ID** | Right-click your username → **Copy User ID** |
 
-**Is my data sent anywhere?**
-> No. This tool runs 100% locally. All data is stored on your machine and never transmitted to external servers.
+---
 
-**Is this compliant with Discord's Terms of Service?**
-> When used responsibly for personal archival with safe rate limit settings, yes. Aggressive scraping or misuse may violate the ToS.
+## 🆕 Recent Updates
+
+### v2.0 — Stability & Usability Overhaul
+- **`install.bat`** — one-click Windows installer that sets up everything automatically
+- **`.env` configuration** — no more editing Python code to change settings; use the `.env` file
+- **Cancellation support** — stop a running download at any time via the UI or `/api/cancel`
+- **Concurrent download protection** — starting a second download while one is running now returns a clear error instead of corrupting state
+- **Proper error logging** — all errors are now logged with context instead of being silently swallowed
+- **Fixed startup banner** — now shows your actual configured values instead of hardcoded numbers
+- **CORS locked to localhost** — the API is no longer exposed to other origins
+- **Python 3.13+ compatibility** — `audioop-lts` dependency is now conditional on Python version
+- **Flexible dependencies** — `requirements.txt` now uses `>=` versions so pip finds the right wheels for your Python version
+
+---
+
+## 🔮 Coming Soon
+
+- [ ] **HTML export** — browse your archive like a real chat interface in your browser
+- [ ] **DM backup support** — archive direct messages and group DMs
+- [ ] **Scheduled backups** — run automatic archives on a timer
+- [ ] **Search & filter** — find specific messages inside a saved archive
+- [ ] **CSV export** — open your messages directly in Excel or Google Sheets
+- [ ] **Incremental backups** — only download new messages since your last archive
+- [ ] **Theme toggle** — light mode option for the web UI
 
 ---
 
 ## 🔧 Troubleshooting
 
-| Issue | Solution |
-|-------|----------|
-| "Invalid bot token" | Verify the token is complete; try resetting it in the Developer Portal |
-| "Server not found" | Ensure the bot has been invited to the target server |
-| "No messages found" | Verify your User ID is correct and you have messages in accessible channels |
-| Python 3.13+ compatibility | Run `pip install audioop-lts` if you encounter audio-related errors |
+| Problem | Solution |
+|---------|----------|
+| "Invalid bot token" | Verify the token is complete — try resetting it in the Developer Portal |
+| "Server not found" | Make sure the bot has been invited to the server |
+| "No messages found" | Check your User ID is correct and the bot can see those channels |
+| "A download is already in progress" | Wait for the current download to finish or click Cancel |
+| `pip install` fails | Make sure Python 3.10+ is installed and on your PATH |
+| Port already in use | Change `PORT=5000` to another port in your `.env` file |
+
+---
+
+## 📖 How It Works
+
+```
+Browser UI  →  Flask API  →  Discord Bot (discord.py)
+                                    ↓
+                          Reads message history
+                          via official Discord API
+                                    ↓
+                          Filters by channel / user / date
+                                    ↓
+                          Downloads attachments (optional)
+                                    ↓
+                          Packages everything into a ZIP
+                                    ↓
+                          Download or save to disk
+```
+
+1. You enter your bot token and server ID in the browser UI
+2. A Discord bot connects using the official `discord.py` library
+3. It scans selected channels and collects message history
+4. Optionally downloads attachments in parallel batches
+5. Everything is packaged into a ZIP archive on your machine
+6. You download the ZIP or save it to the local `downloads/` folder
 
 ---
 
 ## 🤝 Contributing
 
-Contributions are welcome! Please ensure any changes maintain compliance with Discord's Terms of Service.
+Contributions are welcome! Please make sure any changes stay compliant with Discord's Terms of Service.
 
 1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/improvement`)
-3. Commit your changes (`git commit -m 'Add improvement'`)
-4. Push to the branch (`git push origin feature/improvement`)
+2. Create a feature branch: `git checkout -b feature/your-feature`
+3. Commit your changes: `git commit -m 'Add your feature'`
+4. Push: `git push origin feature/your-feature`
 5. Open a Pull Request
 
 ---
 
 ## 📄 License
 
-This project is licensed under the MIT License — see the [LICENSE](LICENSE) file for details.
+MIT License — see [LICENSE](LICENSE) for details.
 
 ---
 
 ## ⚠️ Disclaimer
 
-This software is provided "as-is" for personal archival purposes. The developers assume no liability for:
-
-- Violations of Discord's Terms of Service
-- Account suspensions or terminations resulting from misuse
-- Privacy violations or non-compliance with data protection regulations (GDPR, CCPA, etc.)
-- Any damages arising from the use of this software
+This software is provided "as-is" for personal archival purposes. The developers assume no liability for violations of Discord's Terms of Service, account suspensions, privacy violations, or any damages arising from the use of this software.
 
 **Use responsibly and at your own risk.**
 
 ---
 
-**Made for personal data sovereignty and digital archival.**
+*Built for personal data sovereignty and digital archival.*

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Discord Message Archiver - Full Edition</title>
+    <title>Discord Archiver</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Lexend:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">


### PR DESCRIPTION
- Rename project to discord-archiver across README and index.html title
- Rewrite README with detailed setup guide, feature table, architecture overview, recent updates changelog, coming soon roadmap, and improved troubleshooting section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated setup guide with easier Windows quick-start using batch installers
  * Added dedicated Discord Bot configuration section with explicit OAuth2 steps
  * Streamlined "How to Find Your IDs" and troubleshooting sections

* **New Features**
  * ZIP-based export model with optional per-user archives and attachments
  * Configurable filtering by user, channel, and date range
  * Cancellable download operations
  * Environment-based configuration (`.env`) for port and concurrency settings
  * Enhanced metadata in export archives

* **Rebranding**
  * Project renamed to "Discord Archiver" with refreshed branding across documentation and interface

<!-- end of auto-generated comment: release notes by coderabbit.ai -->