### PR TITLE
Add in-app update notification banner

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,6 +14,7 @@ import io
 import zipfile
 import threading
 import logging
+import urllib.request
 import aiohttp
 import base64
 from datetime import datetime, timezone
@@ -40,6 +41,8 @@ CORS(app, origins=["http://localhost:5000", "http://127.0.0.1:5000"])
 CONCURRENT_CHANNELS = int(os.getenv("CONCURRENT_CHANNELS", "1"))
 CONCURRENT_DOWNLOADS = int(os.getenv("CONCURRENT_DOWNLOADS", "5"))
 PORT = int(os.getenv("PORT", "5000"))
+APP_VERSION = "1.0.0"
+GITHUB_REPO = "TanaTTV/Discord-Archiver"
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # GLOBAL STATE
@@ -468,6 +471,25 @@ def start_fetch_channels_thread(bot_token: str, server_id: int):
 @app.route('/')
 def index():
     return render_template('index.html')
+
+
+@app.route('/api/version')
+def version_check():
+    try:
+        url = f"https://api.github.com/repos/{GITHUB_REPO}/releases/latest"
+        req = urllib.request.Request(url, headers={"User-Agent": "Discord-Archiver"})
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            data = json.loads(resp.read())
+            latest = data.get("tag_name", "").lstrip("v")
+            return jsonify({
+                "current": APP_VERSION,
+                "latest": latest,
+                "update_available": latest != APP_VERSION and latest != "",
+                "release_url": data.get("html_url", f"https://github.com/{GITHUB_REPO}/releases")
+            })
+    except Exception as e:
+        log.warning(f"Update check failed: {e}")
+        return jsonify({"current": APP_VERSION, "update_available": False})
 
 
 @app.route('/api/fetch-channels', methods=['POST'])

--- a/templates/index.html
+++ b/templates/index.html
@@ -805,6 +805,63 @@
             display: block;
         }
 
+        /* Update banner */
+        .update-banner {
+            display: none;
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            z-index: 1000;
+            background: linear-gradient(135deg, #16a34a 0%, #15803d 100%);
+            color: white;
+            padding: 10px 20px;
+            text-align: center;
+            font-size: 14px;
+            font-weight: 500;
+            box-shadow: 0 2px 12px rgba(0,0,0,0.3);
+            animation: slideDown 0.4s ease;
+        }
+
+        .update-banner.active {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 12px;
+        }
+
+        @keyframes slideDown {
+            from { transform: translateY(-100%); opacity: 0; }
+            to { transform: translateY(0); opacity: 1; }
+        }
+
+        .update-banner a {
+            color: white;
+            font-weight: 700;
+            text-decoration: underline;
+            white-space: nowrap;
+        }
+
+        .update-banner-dismiss {
+            position: absolute;
+            right: 16px;
+            background: none;
+            border: none;
+            color: white;
+            font-size: 18px;
+            cursor: pointer;
+            opacity: 0.8;
+            line-height: 1;
+        }
+
+        .update-banner-dismiss:hover {
+            opacity: 1;
+        }
+
+        body.has-banner .container {
+            padding-top: 80px;
+        }
+
         /* Scrollbar */
         ::-webkit-scrollbar {
             width: 8px;
@@ -826,8 +883,15 @@
     </style>
 </head>
 <body>
+    <!-- Update notification banner -->
+    <div class="update-banner" id="updateBanner">
+        <span>🎉 A new version of Discord Archiver is available!</span>
+        <a id="updateLink" href="#" target="_blank">Download latest release →</a>
+        <button class="update-banner-dismiss" onclick="dismissUpdate()">✕</button>
+    </div>
+
     <div class="bg-pattern"></div>
-    
+
     <div class="container">
         <header class="header">
             <div class="logo">🗄️</div>
@@ -1107,6 +1171,26 @@
         let pollInterval = null;
         let selectedChannels = new Set();
         let allChannelIds = [];
+
+        // Check for updates on load
+        async function checkForUpdate() {
+            try {
+                const resp = await fetch('/api/version');
+                const data = await resp.json();
+                if (data.update_available) {
+                    document.getElementById('updateLink').href = data.release_url;
+                    document.getElementById('updateBanner').classList.add('active');
+                    document.body.classList.add('has-banner');
+                }
+            } catch (_) {}
+        }
+
+        function dismissUpdate() {
+            document.getElementById('updateBanner').classList.remove('active');
+            document.body.classList.remove('has-banner');
+        }
+
+        checkForUpdate();
 
         // Options state
         const options = {


### PR DESCRIPTION
- Add APP_VERSION and GITHUB_REPO constants to app.py
- Add /api/version endpoint that checks GitHub Releases API for latest version and returns current vs latest with release URL
- Add green banner in index.html that appears on page load if a newer release is available, with a link to the release page and a dismiss button

## What does this PR do?

<!-- A short summary of the change -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor / cleanup
- [ ] Other (describe below)

## How to test it

<!-- Step-by-step instructions to verify your change works -->

1.
2.
3.

## Checklist

- [ ] Tested locally (`python app.py`)
- [ ] Doesn't raise concurrency or rate limit concerns
- [ ] Doesn't expose credentials or user data
- [ ] README updated if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added update notification feature that alerts users when a new version is available, with the ability to dismiss the banner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->